### PR TITLE
Feature: better display

### DIFF
--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -738,23 +738,23 @@ void Display::showWeightWithFlowAndTimer(float weight) {
     String intStr = String(integerPart);
     display->setCursor(currentX, weightY);
     display->print(intStr);
-    
-    // Calculate position after integer part
-    display->getTextBounds(intStr, 0, 0, &x1, &y1, &w, &h);
-    currentX += w;
-    
-    // Draw smaller decimal point (size 1) positioned to align with baseline
-    display->setTextSize(1);
-    display->setCursor(currentX, weightY + 11); // Offset from weight baseline for alignment
-    display->print(".");
-    display->getTextBounds(".", 0, 0, &x1, &y1, &w, &h);
-    currentX += w;
-    
-    // Draw decimal digit in size 2 for better readability
-    display->setTextSize(2);
-    display->setCursor(currentX, weightY + 3); // Positioned relative to weight baseline
-    display->print(String(decimalPart));
-    
+    if (!isNegative && integerPart < 100){
+        // Calculate position after integer part
+        display->getTextBounds(intStr, 0, 0, &x1, &y1, &w, &h);
+        currentX += w;
+        
+        // Draw smaller decimal point (size 1) positioned to align with baseline
+        display->setTextSize(1);
+        display->setCursor(currentX, weightY + 11); // Offset from weight baseline for alignment
+        display->print(".");
+        display->getTextBounds(".", 0, 0, &x1, &y1, &w, &h);
+        currentX += w;
+        
+        // Draw decimal digit in size 2 for better readability
+        display->setTextSize(2);
+        display->setCursor(currentX, weightY + 3); // Positioned relative to weight baseline
+        display->print(String(decimalPart));
+    }
     // Right side: Timer and flow rate stacked (size 2)
     display->setTextSize(2);
     


### PR DESCRIPTION
I modify Display.cpp for:
1) fixed the bug, when you open status page and press tare or sleep, message overlap with status page and make mess. 
2) when it's negative value or over 99 grams, decimals not shown
3) when timer exceeds 60 seconds,  it switch from ss.sT to m:ss format. I think 60 secs is sufficient to remember where timer is so i drop "T" label 🤣