### PR TITLE
Sleep power savings

### DIFF
--- a/include/BoardConfig.h
+++ b/include/BoardConfig.h
@@ -18,13 +18,15 @@
 #endif
 
 // Pin definitions (currently identical for both boards)
-#define HX711_DATA_PIN      5   // GPIO5 - HX711 Data pin
-#define HX711_CLOCK_PIN     6   // GPIO6 - HX711 Clock pin  
-#define TOUCH_TARE_PIN      4   // GPIO4 - Touch sensor for tare (T0)
-#define TOUCH_SLEEP_PIN     3   // GPIO3 - Touch sensor for sleep functionality
-#define BATTERY_PIN         7   // GPIO7 - Battery voltage monitoring (ADC1_CH6)
-#define I2C_SDA_PIN         8   // GPIO8 - I2C Data pin for display
-#define I2C_SCL_PIN         9   // GPIO9 - I2C Clock pin for display
+#define HX711_DATA_PIN        5   // GPIO5 - HX711 Data pin
+#define HX711_CLOCK_PIN       6   // GPIO6 - HX711 Clock pin  
+#define TOUCH_TARE_PIN        4   // GPIO4 - Touch sensor for tare (T0)
+#define TOUCH_SLEEP_PIN       3   // GPIO3 - Touch sensor for sleep functionality
+#define BATTERY_PIN           7   // GPIO7 - Battery voltage monitoring (ADC1_CH6)
+#define I2C_SDA_PIN           8   // GPIO8 - I2C Data pin for display
+#define I2C_SCL_PIN           9   // GPIO9 - I2C Clock pin for display
+#define OLED_POWER_PIN        2   // GPIO2 - Power control for OLED display
+#define TOUCH_TARE_POWER_PIN  10  // GPIO10 - Power control for tare touch sensor
 
 // Board-specific configurations
 #ifdef BOARD_TYPE_SUPERMINI

--- a/include/Display.h
+++ b/include/Display.h
@@ -31,6 +31,7 @@ public:
     void showIPAddresses(); // Show startup ready message
     void showStatusPage(); // Show status page with battery, BLE, WiFi, and scale status
     void toggleStatusPage(); // Toggle between main display and status page
+    void setPowerSave(bool enable);
     void clear();
     void setBrightness(uint8_t brightness);
     

--- a/include/PowerManager.h
+++ b/include/PowerManager.h
@@ -8,7 +8,7 @@ class Display; // Forward declaration
 
 class PowerManager {
 public:
-    PowerManager(uint8_t sleepTouchPin, Display* display = nullptr);
+    PowerManager(uint8_t sleepTouchPin, uint8_t clockPin, Display* display = nullptr);
     void begin();
     void update();
     void enterDeepSleep();
@@ -22,6 +22,7 @@ public:
     
 private:
     uint8_t sleepTouchPin;
+    uint8_t clockPin;
     Display* displayPtr;
     uint16_t sleepTouchThreshold;
     bool lastSleepTouchState;

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -614,6 +614,10 @@ void Display::showIPAddresses() {
     delay(1000); // Show ready message for 1 second, then continue to normal display
 }
 
+void Display::setPowerSave(bool enable) {
+    display->ssd1306_command(enable ? 0xae : 0xaf);
+}
+
 void Display::clear() {
     // Return early if display is not connected
     if (!displayConnected) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -1,8 +1,13 @@
 #include "PowerManager.h"
 #include "Display.h"
+#include "Scale.h"
+#include "soc/rtc.h"
+#include "soc/rtc_cntl_reg.h"
+#include "driver/rtc_io.h"
 
-PowerManager::PowerManager(uint8_t sleepTouchPin, Display* display) 
-    : sleepTouchPin(sleepTouchPin), displayPtr(display), sleepTouchThreshold(0),
+
+PowerManager::PowerManager(uint8_t sleepTouchPin, uint8_t clockPin, Display* display) 
+    : sleepTouchPin(sleepTouchPin), clockPin(clockPin), displayPtr(display), sleepTouchThreshold(0),
       lastSleepTouchState(false), lastSleepTouchTime(0), touchStartTime(0),
       debounceDelay(200), sleepCountdownStart(0), sleepCountdownActive(false),
       longPressDetected(false), cancelledRecently(false), cancelTime(0),
@@ -13,14 +18,7 @@ void PowerManager::begin() {
     // Set up the pin as digital input with pull-down resistor for the digital touch sensor module
     // This prevents false triggers when no touch sensor is connected
     pinMode(sleepTouchPin, INPUT_PULLDOWN);
-    
-    // Configure external wake-up on the touch pin
-    // Wake up when pin goes HIGH (touch sensor outputs HIGH when touched)
-    esp_sleep_enable_ext0_wakeup((gpio_num_t)sleepTouchPin, 1);
-    
-    Serial.println("Power Manager initialized. Sleep touch sensor on GPIO" + String(sleepTouchPin));
-    Serial.println("Using EXT0 wake-up (digital touch sensor) with pull-down resistor");
-    Serial.println("Device will wake up when touch sensor outputs HIGH");
+    Serial.println("Power Manager initialized");
 }
 
 void PowerManager::update() {
@@ -108,14 +106,22 @@ void PowerManager::enterDeepSleep() {
         displayPtr->showGoingToSleepMessage();
         delay(2000);
         displayPtr->clear();
+        displayPtr->setPowerSave(1);
     }
     
     // Print wake-up configuration for debugging
-    Serial.println("Wake-up configured for EXT0 on GPIO" + String(sleepTouchPin));
+    Serial.println("Wake-up configured for EXT1 on GPIO" + String(sleepTouchPin));
     Serial.println("Will wake when pin goes HIGH");
     
     // Flush serial output
     Serial.flush();
+
+    // Hold the scales clock pin high to turn it off
+    digitalWrite(clockPin, HIGH);
+    gpio_hold_en((gpio_num_t) clockPin);
+
+    // Configure touch wake up
+    esp_sleep_enable_ext1_wakeup(1ULL << sleepTouchPin, ESP_EXT1_WAKEUP_ANY_HIGH);
     
     // Enter deep sleep - will wake up on external signal
     esp_deep_sleep_start();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,29 +15,40 @@
 #include "BluetoothScale.h"
 #include "TouchSensor.h"
 #include "Display.h"
+#include "BoardConfig.h"
 #include "PowerManager.h"
 #include "BatteryMonitor.h"
-#include "BoardConfig.h"
 #include "Version.h"
 
 // Board-specific pin configuration
-uint8_t dataPin = HX711_DATA_PIN;     // HX711 Data pin
-uint8_t clockPin = HX711_CLOCK_PIN;   // HX711 Clock pin  
-uint8_t touchPin = TOUCH_TARE_PIN;    // Touch sensor for tare
-uint8_t sleepTouchPin = TOUCH_SLEEP_PIN;  // Touch sensor for sleep functionality
-uint8_t batteryPin = BATTERY_PIN;     // Battery voltage monitoring
-uint8_t sdaPin = I2C_SDA_PIN;         // I2C Data pin for display
-uint8_t sclPin = I2C_SCL_PIN;         // I2C Clock pin for display
+uint8_t dataPin = HX711_DATA_PIN;                 // HX711 Data pin
+uint8_t clockPin = HX711_CLOCK_PIN;               // HX711 Clock pin  
+uint8_t touchPin = TOUCH_TARE_PIN;                // Touch sensor for tare
+uint8_t sleepTouchPin = TOUCH_SLEEP_PIN;          // Touch sensor for sleep functionality
+uint8_t batteryPin = BATTERY_PIN;                 // Battery voltage monitoring
+uint8_t sdaPin = I2C_SDA_PIN;                     // I2C Data pin for display
+uint8_t sclPin = I2C_SCL_PIN;                     // I2C Clock pin for display
+uint8_t oledPowerPin = OLED_POWER_PIN;            // Power control for OLED display
+uint8_t touchTarePowerPin = TOUCH_TARE_POWER_PIN; // Power control for tare touch sensor
 float calibrationFactor = 4195.712891;
 Scale scale(dataPin, clockPin, calibrationFactor);
 FlowRate flowRate;
 BluetoothScale bluetoothScale;
 TouchSensor touchSensor(touchPin, &scale);
 Display oledDisplay(sdaPin, sclPin, &scale, &flowRate);
-PowerManager powerManager(sleepTouchPin, &oledDisplay);
+PowerManager powerManager(sleepTouchPin, clockPin, &oledDisplay);
 BatteryMonitor batteryMonitor(batteryPin);
 
 void setup() {
+  // Activate pins to power tare sensor and OLED display, they become high impedance during sleep
+  pinMode(touchTarePowerPin, OUTPUT);
+  digitalWrite(touchTarePowerPin, HIGH);
+  pinMode(oledPowerPin, OUTPUT);
+  digitalWrite(oledPowerPin, HIGH);
+
+  // disable GPIO hold from previous sleep cycles to ensure scales are active
+  gpio_hold_dis((gpio_num_t) clockPin);
+
   Serial.begin(115200);
   
   // Set CPU frequency explicitly for power optimization
@@ -205,7 +216,7 @@ void setup() {
     }
     
     Serial.println("Forcing deep sleep now...");
-    esp_deep_sleep_start();
+    powerManager.enterDeepSleep();
   }
   
   Serial.printf("Battery voltage OK (%.2fV) - continuing boot\n", batteryVoltage);


### PR DESCRIPTION
## Summary
These are a few small changes that greatly improve sleep power consumption.
~4.5mA from the scales
~0.5mA from the display
~2mA from the tare sensor
~0.1mA changing to EXT1

Further improvements can be made by removing onboard LEDs but this is ~5mA for unmodified hardware (or ~7mA moving tare power) saved in deep sleep.

## Type of Change
- [X] Performance improvement

## Changes Made
- Added pins to power tare touchpad and OLED, they are set high in setup() then during sleep they turn off saving power.
- Added OLED power off, so it goes from 0.53mA to 7.5uA during sleep if not powering from the new pin.
- Changed wake up source from EXT0 to EXT1, functionally the same but lower sleep consumption.
- Touch to wake not disabled if battery low, otherwise it required a power cycle after charging.
- Set hx711 clock pin to hold high during sleep, going from 4.5mA to zero during sleep.

## Testing
- [X] I have tested this change on actual hardware
- [X] I have tested the web interface (if applicable)
- [X] I have verified WiFi functionality works correctly
- [ ] I have tested with different coffee scale configurations

## Hardware Tested On
- [X] ESP32-S3 SuperMini
- [ ] ESP32-S3 DevKit
- [ ] Other ESP32 variant (please specify): ___________

## Screenshots (if applicable)
Add screenshots of web interface changes or OLED display updates.

## Checklist
- [X] My code follows the existing code style
- [X] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation (if needed)
- [X] My changes generate no new compiler warnings
- [X] I have tested that existing functionality still works

## Additional Notes
Any additional information, context, or concerns about this PR.